### PR TITLE
Using versions py

### DIFF
--- a/common/targets/Minion.Common.targets
+++ b/common/targets/Minion.Common.targets
@@ -29,11 +29,13 @@
   -->
   <Target Name="setVersionProperties">
 
-    <Error Condition="'$(DisplayVersion)'=='' And '$(InternalVersion)'=='' And '$(Version)'==''" Text="Must set one of: Version, DisplayVersion" />
+    <Error Condition="'$(DisplayVersion)'==''"  Text="Must set DisplayVersion" />
+    <Error Condition="'$(InternalVersion)'==''" Text="Must set InternalVersion" />
 
+    <!-- DO NOT CALCULATE         REQUIRE DisplayVersion And InternalVersion    DUMP Version?
     <PropertyGroup>
       <DisplayVersion Condition="'$(DisplayVersion)'=='' And '$(Version)'!=''">$(Version)</DisplayVersion>
-      <YearPosition>$(DisplayVersion.IndexOf('2'))</YearPosition> <!-- We are not afraid of Y3K! -->
+      <YearPosition>$(DisplayVersion.IndexOf('2'))</YearPosition> 
       <DashPosition>$(DisplayVersion.IndexOf('-'))</DashPosition>
       <InternalVersionStartIndex>$([MSBuild]::Add($(YearPosition),2))</InternalVersionStartIndex>
       <InternalVersionCalculatedLength Condition="$(DashPosition)&gt;0">$([MSBuild]::Subtract($(DashPosition),$(InternalVersionStartIndex)))</InternalVersionCalculatedLength>
@@ -42,11 +44,15 @@
       <InternalVersion Condition="'$(InternalVersion)'==''">$(CalculatedInternalVersion)</InternalVersion>
       <InternalVersion Condition="'$(BUILD_NUMBER)'!=''">$(InternalVersion).$(BUILD_NUMBER)</InternalVersion>
     </PropertyGroup>
-
+    -->
+    
+    <Message Text="******************************************************************************   "/>
     <Message Text="****************** common/targets/Minion.Common.targets **********************   "/>    
     <Message Text="        DisplayVersion  = $(DisplayVersion)"/>
     <Message Text="        InternalVersion = $(InternalVersion)"/>
-
+    <Message Text="        Version         = $(Version)"/>    
+    <Message Text="******************************************************************************   "/>
+    
     <PropertyGroup>
       <DefineConstants>$(DefineConstants);DisplayVersion=$(DisplayVersion);InternalVersion=$(InternalVersion)</DefineConstants>
       <TargetName>Salt-Minion-$(DisplayVersion)-$(TargetPlatform)-Setup</TargetName>

--- a/versionDisplay.cmd
+++ b/versionDisplay.cmd
@@ -1,0 +1,2 @@
+@echo off
+python versionDisplayOrInternal.py

--- a/versionDisplayOrInternal.py
+++ b/versionDisplayOrInternal.py
@@ -1,0 +1,29 @@
+# 2016-12-02 Markus   
+# show DisplayVersion or InternalVersion
+#
+# Could be much nicer but I don't know how to access the class in version
+# So __version__ is all I have
+# Could also be directly in version.py
+
+from __future__ import absolute_import, print_function
+
+import sys
+sys.path.insert(0, '../salt/salt')   # as long salt-windows-msi is not salt
+import version
+
+DisplayVersion = version.__version__                                      # e.g.       2016.3.2-72-gc1deb94
+version_list   = DisplayVersion.replace('.',' ').replace('-',' ').split() # all elements are strings
+year    = version_list[0]
+minor   = version_list[1]
+bugfix  = version_list[2]
+InternalVersion =  year[2:] + '.' + minor + '.' + bugfix 
+if len(version_list) > 3:
+	InternalVersion += '.' + version_list[3]
+
+show_internal = len(sys.argv) > 1 and sys.argv[1] == 'i'
+if show_internal:
+	print(InternalVersion)
+else:
+	print(DisplayVersion)
+
+

--- a/versionInternal.cmd
+++ b/versionInternal.cmd
@@ -1,0 +1,2 @@
+@echo off
+python versionDisplayOrInternal.py i

--- a/wix/MinionMSI/MinionMSI.wixproj
+++ b/wix/MinionMSI/MinionMSI.wixproj
@@ -18,6 +18,11 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>Debug</DefineConstants>
+    <WixVariables>
+    </WixVariables>
+    <CompilerAdditionalOptions>
+    </CompilerAdditionalOptions>
+    <LinkerAdditionalOptions>DisplayVersion=2020.1.1</LinkerAdditionalOptions>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/ybuild.cmd
+++ b/ybuild.cmd
@@ -1,13 +1,11 @@
-:: 2016-11-07  Markus Kramer   This is a first attempt to automate the salt-windows-msi project.
-::                             The version is hard coded.
 @echo off
-:: Get the version from git if not passed
-if [%1]==[] (
-    for /f "delims=" %%a in ('git describe') do @set "Version=%%a"
-) else (
-    set "Version=%~1"
-)
-@echo %0 :: Version %Version%
+
+:: Get the versions from salt/version.py
+for /f "delims=" %%a in ('python versionDisplayOrInternal.py i') do @set "iii=%%a"
+for /f "delims=" %%a in ('python versionDisplayOrInternal.py')   do @set "ddd=%%a"
+
+@echo %0 :: DisplayVersion  = %ddd%
+@echo %0 :: InternalVersion = %iii%
 @echo.
 
-c:\windows\microsoft.net\framework\v4.0.30319\msbuild.exe msbuild.proj /t:wix /p:TargetPlatform=amd64 /p:Version=%Version%
+c:\windows\microsoft.net\framework\v4.0.30319\msbuild.exe msbuild.proj /t:wix /p:TargetPlatform=amd64 /p:DisplayVersion=%ddd% /p:InternalVersion=%iii%

--- a/yclean.cmd
+++ b/yclean.cmd
@@ -2,14 +2,12 @@
 :: 2016-11-07  Markus Kramer   version required to clean. This is strange.
 
 @echo off
-:: Get the version from git if not passed
-if [%1]==[] (
-    for /f "delims=" %%a in ('git describe') do @set "Version=%%a"
-) else (
-    set "Version=%~1"
-)
-@echo %0 :: Version %Version%
+:: Get the versions from salt/version.py
+for /f "delims=" %%a in ('python versionDisplayOrInternal.py')   do @set "ddd=%%a"
+
+@echo %0 :: DisplayVersion  = %ddd%
 @echo.
 
 
-c:\windows\microsoft.net\framework\v4.0.30319\msbuild.exe msbuild.proj /t:clean /p:Version=%Version%
+
+c:\windows\microsoft.net\framework\v4.0.30319\msbuild.exe msbuild.proj /t:clean /p:Version=%ddd%

--- a/yinstall.cmd
+++ b/yinstall.cmd
@@ -1,11 +1,8 @@
 @echo off
-:: Get the version from git if not passed
-if [%1]==[] (
-    for /f "delims=" %%a in ('git describe') do @set "Version=%%a"
-) else (
-    set "Version=%~1"
-)
-@echo %0 :: Version %Version%
+:: Get the versions from salt/version.py
+for /f "delims=" %%a in ('python versionDisplayOrInternal.py') do @set "ddd=%%a"
+
+@echo %0 :: DisplayVersion  = %ddd%
 @echo.
 
-msiexec /i wix\MinionMSI\bin\Release\Salt-Minion-%version%-amd64-Setup.msi /qn /l*v yinstall.log
+msiexec /i wix\MinionMSI\bin\Release\Salt-Minion-%ddd%-amd64-Setup.msi /qn /l*v yinstall.log

--- a/yinstallGUI.cmd
+++ b/yinstallGUI.cmd
@@ -1,11 +1,8 @@
 @echo off
-:: Get the version from git if not passed
-if [%1]==[] (
-    for /f "delims=" %%a in ('git describe') do @set "Version=%%a"
-) else (
-    set "Version=%~1"
-)
-@echo %0 :: Version %Version%
+:: Get the versions from salt/version.py
+for /f "delims=" %%a in ('python versionDisplayOrInternal.py')   do @set "ddd=%%a"
+
+@echo %0 :: DisplayVersion  = %ddd%
 @echo.
 
-msiexec /i wix\MinionMSI\bin\Release\Salt-Minion-%version%-amd64-Setup.msi /l*v yinstall.log
+msiexec /i wix\MinionMSI\bin\Release\Salt-Minion-%ddd%-amd64-Setup.msi /l*v yinstall.log

--- a/yuninstall.cmd
+++ b/yuninstall.cmd
@@ -1,11 +1,8 @@
 @echo off
-:: Get the version from git if not passed
-if [%1]==[] (
-    for /f "delims=" %%a in ('git describe') do @set "Version=%%a"
-) else (
-    set "Version=%~1"
-)
-@echo %0 :: Version %Version%
+:: Get the versions from salt/version.py
+for /f "delims=" %%a in ('python versionDisplayOrInternal.py')   do @set "ddd=%%a"
+
+@echo %0 :: DisplayVersion  = %ddd%
 @echo.
 
-msiexec /x wix\MinionMSI\bin\Release\Salt-Minion-%version%-amd64-Setup.msi /qn /l*v yinstall.log
+msiexec /x wix\MinionMSI\bin\Release\Salt-Minion-%ddd%-amd64-Setup.msi /qn /l*v yinstall.log


### PR DESCRIPTION
WiX now requires DisplayVersion and InternalVersion
WiX no longer calculates any version
salt/version.py calculates versions.

The MinionExe project died.
